### PR TITLE
fix: shut down MQTT TCP socket and WiFi radio before deep sleep (~250 mW regression)

### DIFF
--- a/esp32_rtsp_mic_birdnetgo/esp32_rtsp_mic_birdnetgo.ino
+++ b/esp32_rtsp_mic_birdnetgo/esp32_rtsp_mic_birdnetgo.ino
@@ -1119,12 +1119,28 @@ void checkDeepSleepSchedule() {
     }
     lastStreamStopReason = "Deep sleep outside stream schedule";
     lastStreamStopMs = millis();
-    mqttPublishState(true);
-    delay(40);
+    // Publish final state + mark offline, then cleanly close MQTT TCP socket.
+    // An open TCP connection prevents the WiFi modem from powering down during
+    // deep sleep, causing ~250 mW standby instead of near-zero consumption.
+    if (mqttClient.connected()) {
+        if (!mqttPublishState(true))
+            simplePrintln("Deep sleep: MQTT state publish failed (non-fatal).");
+        if (!mqttClient.publish(mqttAvailabilityTopic().c_str(), "offline", true))
+            simplePrintln("Deep sleep: MQTT offline publish failed (non-fatal), LWT will cover it.");
+        mqttClient.loop();  // flush TX buffer before closing socket
+        mqttClient.disconnect();
+        // 200 ms covers remote brokers (RTT up to ~100 ms) for a clean TCP
+        // FIN/ACK exchange; LWT is the fallback if the close does not complete.
+        delay(200);
+    }
+    // Shut down WiFi radio so the modem is fully off before deep sleep.
+    WiFi.disconnect(true);
+    WiFi.mode(WIFI_OFF);
+    delay(100);  // allow modem hardware to power down
 
     esp_sleep_enable_timer_wakeup((uint64_t)sleepSec * 1000000ULL);
+    simplePrintln("WiFi off. Entering deep sleep now.");
     Serial.flush();
-    delay(30);
     esp_deep_sleep_start();
 }
 


### PR DESCRIPTION
## Problem

Deep sleep consumes **~250 mW** instead of near-zero since v1.6.0.

**Root cause:** v1.6.0 added MQTT (`PubSubClient` / `WiFiClient`), which keeps an active TCP connection to the broker. Calling `esp_deep_sleep_start()` with an open socket prevents the WiFi modem from powering down — the radio stays active during sleep.

v1.5.0 was unaffected because it had no persistent TCP connections at sleep time.

## Fix

Before `esp_deep_sleep_start()`, explicitly tear down the network stack:

1. Publish final MQTT state + `"offline"` to the availability topic
2. `mqttClient.loop()` — flush TX buffer
3. `mqttClient.disconnect()` + 200 ms — clean TCP FIN/ACK (LWT as fallback for slow/remote brokers)
4. `WiFi.disconnect(true)` + `WiFi.mode(WIFI_OFF)` + 100 ms — fully power down the radio

## Verification

Measured with USB power meter on XIAO ESP32-C6:
- **Before fix (v1.6.0):** ~250 mW during deep sleep
- **After fix:** ~0 W during deep sleep (same as v1.5.0)

## Scope

Single function `checkDeepSleepSchedule()` in `esp32_rtsp_mic_birdnetgo.ino`. No other files changed. No new features, no behaviour change outside the deep sleep path.